### PR TITLE
Fix compilation of assimp on linux

### DIFF
--- a/contrib/zlib/gzguts.h
+++ b/contrib/zlib/gzguts.h
@@ -43,7 +43,7 @@
 #  define WIDECHAR
 #endif
 
-#ifdef WINAPI_FAMILY
+#ifdef _MSC_VER
 #  define open _open
 #  define read _read
 #  define write _write

--- a/contrib/zlib/gzlib.c
+++ b/contrib/zlib/gzlib.c
@@ -244,7 +244,7 @@ local gzFile gz_open(path, fd, mode)
 #ifdef WIDECHAR
         fd == -2 ? _wopen(path, oflag, 0666) :
 #endif
-        _open((const char *)path, oflag, 0666));
+        open((const char *)path, oflag, 0666));
     if (state->fd == -1) {
         free(state->path);
         free(state);

--- a/contrib/zlib/gzread.c
+++ b/contrib/zlib/gzread.c
@@ -32,7 +32,7 @@ local int gz_load(state, buf, len, have)
         get = len - *have;
         if (get > max)
             get = max;
-        ret = _read(state->fd, buf + *have, get);
+        ret = read(state->fd, buf + *have, get);
         if (ret <= 0)
             break;
         *have += (unsigned)ret;
@@ -644,7 +644,7 @@ int ZEXPORT gzclose_r(file)
     err = state->err == Z_BUF_ERROR ? Z_BUF_ERROR : Z_OK;
     gz_error(state, Z_OK, NULL);
     free(state->path);
-    ret = _close(state->fd);
+    ret = close(state->fd);
     free(state);
     return ret ? Z_ERRNO : err;
 }

--- a/contrib/zlib/gzwrite.c
+++ b/contrib/zlib/gzwrite.c
@@ -86,7 +86,7 @@ local int gz_comp(state, flush)
     if (state->direct) {
         while (strm->avail_in) {
             put = strm->avail_in > max ? max : strm->avail_in;
-            writ = _write(state->fd, strm->next_in, put);
+            writ = write(state->fd, strm->next_in, put);
             if (writ < 0) {
                 gz_error(state, Z_ERRNO, zstrerror());
                 return -1;
@@ -116,7 +116,7 @@ local int gz_comp(state, flush)
             while (strm->next_out > state->x.next) {
                 put = strm->next_out - state->x.next > (int)max ? max :
                       (unsigned)(strm->next_out - state->x.next);
-                writ = _write(state->fd, state->x.next, put);
+                writ = write(state->fd, state->x.next, put);
                 if (writ < 0) {
                     gz_error(state, Z_ERRNO, zstrerror());
                     return -1;
@@ -670,7 +670,7 @@ int ZEXPORT gzclose_w(file)
     }
     gz_error(state, Z_OK, NULL);
     free(state->path);
-    if (_close(state->fd) == -1)
+    if (close(state->fd) == -1)
         ret = Z_ERRNO;
     free(state);
     return ret;


### PR DESCRIPTION
_open,_close,_read,_write are windows specific functions and not valid on linux. On linux the posix functions open,close,read,write must be used.